### PR TITLE
Set error true attr on exceptions

### DIFF
--- a/lib/opentelemetry_phoenix.ex
+++ b/lib/opentelemetry_phoenix.ex
@@ -147,7 +147,8 @@ defmodule OpentelemetryPhoenix do
       exception_attrs = [
         {"type", to_string(meta.kind)},
         {"message", meta.reason.message},
-        {"stacktrace", "#{inspect(meta.stacktrace)}"}
+        {"stacktrace", "#{inspect(meta.stacktrace)}"},
+        {"error", "true"}
       ]
 
       # TODO: events don't seem to be supported in Jaeger or Zipkin.
@@ -163,7 +164,8 @@ defmodule OpentelemetryPhoenix do
       # TODO: reason is a %Plug.Conn.WrapperError{} so no message
       exception_attrs = [
         {"type", to_string(meta.kind)},
-        {"stacktrace", "#{inspect(meta.stacktrace)}"}
+        {"stacktrace", "#{inspect(meta.stacktrace)}"},
+        {"error", "true"}
       ]
 
       # TODO: events don't seem to be supported in Jaeger or Zipkin.

--- a/test/opentelemetry_phoenix_test.exs
+++ b/test/opentelemetry_phoenix_test.exs
@@ -219,7 +219,8 @@ defmodule OpentelemetryPhoenixTest do
                           attributes: [
                             {"type", "error"},
                             {"message", "Wrong argument type for x"},
-                            {"stacktrace", stacktrace}
+                            {"stacktrace", stacktrace},
+                            {"error", "true"}
                           ]
                         )
                       ],
@@ -296,7 +297,8 @@ defmodule OpentelemetryPhoenixTest do
                           name: "exception",
                           attributes: [
                             {"type", "error"},
-                            {"stacktrace", stacktrace}
+                            {"stacktrace", stacktrace},
+                            {"error", "true"}
                           ]
                         )
                       ],


### PR DESCRIPTION
Most vendors rely on this attribute for indicating spans with errors.