### PR TITLE
Add method to span name

### DIFF
--- a/lib/opentelemetry_phoenix.ex
+++ b/lib/opentelemetry_phoenix.ex
@@ -131,7 +131,7 @@ defmodule OpentelemetryPhoenix do
 
   def handle_router_dispatch_start(_event, _measurements, meta, _config) do
     if in_span?() do
-      OpenTelemetry.Span.update_name(meta.route)
+      OpenTelemetry.Span.update_name("#{meta.conn.method} #{meta.route}")
 
       attributes = [
         {"phoenix.plug", to_string(meta.plug)},

--- a/test/opentelemetry_phoenix_test.exs
+++ b/test/opentelemetry_phoenix_test.exs
@@ -141,7 +141,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "/users/{user_id}/orders",
+                      name: "GET /users/{user_id}/orders",
                       attributes: list,
                       status: ^expected_status
                     )}
@@ -210,7 +210,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "/users/{user_id}/orders",
+                      name: "GET /users/{user_id}/orders",
                       attributes: list,
                       kind: :SERVER,
                       events: [
@@ -290,7 +290,7 @@ defmodule OpentelemetryPhoenixTest do
 
     assert_receive {:span,
                     span(
-                      name: "/users/{user_id}/orders",
+                      name: "GET /users/{user_id}/orders",
                       attributes: list,
                       events: [
                         event(


### PR DESCRIPTION
Conventions seem to dictate adding the method as the first part of http span names.