### PR TITLE
Register tracer explicitly

### DIFF
--- a/lib/opentelemetry_phoenix.ex
+++ b/lib/opentelemetry_phoenix.ex
@@ -43,7 +43,8 @@ defmodule OpentelemetryPhoenix do
   def setup(opts \\ []) do
     opts = ensure_opts(opts)
 
-    OpenTelemetry.register_application_tracer(@tracer_id)
+    {:ok, otel_phx_vsn} = :application.get_key(@tracer_id, :vsn)
+    OpenTelemetry.register_tracer(@tracer_id, otel_phx_vsn)
 
     attach_endpoint_start_handler(opts)
     attach_endpoint_stop_handler(opts)

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule OpentelemetryPhoenix.MixProject do
   defp package do
     [
       description: "OpenTelemetry tracing for the Phoenix Framework",
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
       licenses: ["Apache-2.0"],
       links: %{
         "GitHub" => "https://github.com/opentelemetry-beam/opentelemetry_phoenix",


### PR DESCRIPTION
For some reason there appears to be an issue of getting the correct tracer when registering it with `register_application_tracer` in testing. For now, we'll just register it directly.