### PR TITLE
Fix parsing of x-forwarded-for header

### DIFF
--- a/lib/opentelemetry_phoenix.ex
+++ b/lib/opentelemetry_phoenix.ex
@@ -204,7 +204,7 @@ defmodule OpentelemetryPhoenix do
       ip_address ->
         ip_address
         |> String.split(",", parts: 2)
-        |> List.first("")
+        |> List.first()
     end
   end
 

--- a/test/opentelemetry_phoenix_test.exs
+++ b/test/opentelemetry_phoenix_test.exs
@@ -78,6 +78,26 @@ defmodule OpentelemetryPhoenixTest do
            ] == List.keysort(list, 0)
   end
 
+  test "parses x-forwarded-for with single value" do
+    OpentelemetryPhoenix.setup()
+
+    x_forwarded_for_request("203.0.113.195")
+
+    assert_receive {:span, span(attributes: list)}
+
+    assert Keyword.fetch!(list, :"http.client_ip") == "203.0.113.195"
+  end
+
+  test "parses x-forwarded-for with multiple values" do
+    OpentelemetryPhoenix.setup()
+
+    x_forwarded_for_request("203.0.113.195, 70.41.3.18, 150.172.238.178")
+
+    assert_receive {:span, span(attributes: list)}
+
+    assert Keyword.fetch!(list, :"http.client_ip") == "203.0.113.195"
+  end
+
   test "records exceptions for Phoenix web requests" do
     OpentelemetryPhoenix.setup()
 
@@ -214,5 +234,29 @@ defmodule OpentelemetryPhoenixTest do
              "phoenix.action": :code_exception,
              "phoenix.plug": MyStoreWeb.PageController
            ] == List.keysort(list, 0)
+  end
+
+  defp x_forwarded_for_request(x_forwarded_for) do
+    meta = Meta.endpoint_start()
+
+    meta = %{
+      meta
+      | conn: %{
+          meta.conn
+          | req_headers: [{"x-forwarded-for", x_forwarded_for} | meta.conn.req_headers]
+        }
+    }
+
+    :telemetry.execute(
+      [:phoenix, :endpoint, :start],
+      %{system_time: System.system_time()},
+      meta
+    )
+
+    :telemetry.execute(
+      [:phoenix, :endpoint, :stop],
+      %{duration: 444},
+      Meta.endpoint_stop()
+    )
   end
 end


### PR DESCRIPTION
The x-forwarded-for header can contain multiple values, where the first value represents the client ip.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
