### PR TITLE
Add case for HTTP/2 flavor

### DIFF
--- a/lib/opentelemetry_phoenix.ex
+++ b/lib/opentelemetry_phoenix.ex
@@ -188,6 +188,7 @@ defmodule OpentelemetryPhoenix do
       :"HTTP/1.0" -> :"1.0"
       :"HTTP/1.1" -> :"1.1"
       :"HTTP/2.0" -> :"2.0"
+      :"HTTP/2" -> :"2.0"
       :SPDY -> :SPDY
       :QUIC -> :QUIC
       nil -> ""


### PR DESCRIPTION
OpentelemetryPhoenix fails to handle the HTTP/2 version as supplied by `cowboy`

cowboy/src/cowboy.erl:40
```
-type http_version() :: 'HTTP/2' | 'HTTP/1.1' | 'HTTP/1.0'.
```

Error Log
```
Handler {OpentelemetryPhoenix, :endpoint_start} has failed and has been detached. Class=:error
Reason={:case_clause, :\"HTTP/2\"}
Stacktrace=[
 {OpentelemetryPhoenix, :http_flavor, 1,
 [file: 'lib/opentelemetry_phoenix.ex', line: 174]},
 {OpentelemetryPhoenix, :handle_endpoint_start, 4,
 [file: 'lib/opentelemetry_phoenix.ex', line: 115]},
 {:telemetry, :\"-execute/3-fun-0-\", 4,
 [
 file: '/home/jenkins/.jenkins/workspace/************/deps/telemetry/src/telemetry.erl',
 line: 135
 ]},
 {:lists, :foreach, 2, [file: 'lists.erl', line: 1338]},
 {Plug.Telemetry, :call, 2, [file: 'lib/plug/telemetry.ex', line: 72]},
 {********Web.Endpoint, :plug_builder_call, 2,
 [file: 'lib/***********/endpoint.ex', line: 1]},
 {**********.Endpoint, :call, 2,
 [file: 'lib/***********/endpoint.ex', line: 1]},
 {Phoenix.Endpoint.Cowboy2Handler, :init, 4,
 [file: 'lib/phoenix/endpoint/cowboy2_handler.ex
```
