### PR TITLE
Bump telemetry version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule OpentelemetryPhoenix.MixProject do
       {:opentelemetry_api, "~> 1.0.0-rc"},
       {:opentelemetry, "~> 1.0.0-rc"},
       {:opentelemetry_telemetry, "~> 1.0.0-beta"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:plug, "~> 1.11", only: [:dev, :test]},
       {:ex_doc, "~> 0.24", only: [:dev], runtime: false},
       {:plug_cowboy, "~> 2.4", only: [:test]},


### PR DESCRIPTION
The bump to 1.0.0 does not bring any breaking change: https://hexdocs.pm/telemetry/changelog.html#1-0-0